### PR TITLE
Counter starts at 0 not 1 in exportmanifest.json

### DIFF
--- a/load_async.py
+++ b/load_async.py
@@ -279,7 +279,7 @@ def setup():
                 data=json.dumps({'count': 1}),
                 content_type='application/json'
             )
-            COUNTER = 1
+            COUNTER = 0
         except Exception as e: 
             print(f"Failed creating counter.json. Exiting with exception: {str(e)}")
             sys.exit()

--- a/load_async.py
+++ b/load_async.py
@@ -276,7 +276,7 @@ def setup():
         try:
             blob = BUCKET.blob(f"{GCP_PATH}/counter.json")
             blob.upload_from_string(
-                data=json.dumps({'count': 1}),
+                data=json.dumps({'count': 0}),
                 content_type='application/json'
             )
             COUNTER = 0

--- a/load_sync.py
+++ b/load_sync.py
@@ -155,7 +155,7 @@ def setup():
         try:
             blob = BUCKET.blob(f"{GCP_PATH_TO_EXPORT}/counter.json")
             blob.upload_from_string(
-                data=json.dumps({'count': 1}),
+                data=json.dumps({'count': 0}),
                 content_type='application/json'
             )
             COUNTER = 0

--- a/load_sync.py
+++ b/load_sync.py
@@ -158,7 +158,7 @@ def setup():
                 data=json.dumps({'count': 1}),
                 content_type='application/json'
             )
-            COUNTER = 1
+            COUNTER = 0
         except Exception as e: 
             print(f"Failed creating counter.json. Exiting with exception: {str(e)}")
             sys.exit()


### PR DESCRIPTION
`counter` in exportmanifest.json starts at 0 not 1. Having the example imply it starts at 1 is very confusing.

- [x] change the initial `counter` to 0 to align with what is produced by the Pendo datasync.